### PR TITLE
Change previous and next question button labels from arrow icons to action words

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ui_design_final",
+  "name": "euismod",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/Pages/About/index.jsx
+++ b/src/Pages/About/index.jsx
@@ -9,7 +9,7 @@ function About() {
     <Container variants={pageVariants} initial="init" animate="anim">
       <Header1>About</Header1>
       <Paragraph fontSize="1.15em">
-        The point of this website is to help people learn CSS grid in a
+        The point of this website is to help people learn CSS grid in an
         interactive fashion.
       </Paragraph>
       <Paragraph fontSize="1.15em">

--- a/src/Pages/Quiz/QuizTemplate.jsx
+++ b/src/Pages/Quiz/QuizTemplate.jsx
@@ -109,21 +109,13 @@ function QuizTemplate({
       <FlexContainer>
         {previousQuestion && (
           <StyledButton to={previousQuestion}>
-            <LeftArrow
-              height="24px"
-              width="24px"
-              fill={isDarkMode ? "white" : "black"}
-            />
+            Previous Question
           </StyledButton>
         )}
 
         {nextQuestion && (
           <StyledButton to={nextQuestion}>
-            <RightArrow
-              height="24px"
-              width="24px"
-              fill={isDarkMode ? "white" : "black"}
-            />
+            Next Question
           </StyledButton>
         )}
       </FlexContainer>


### PR DESCRIPTION
As a first time user on the `Quiz` page, I didn't know the arrow buttons were meant for the user to move across questions. Especially because the  `Submit Quiz` button was under them.

My first instinct was to click the  `Submit Quiz` button even though I was still on the first quiz.

I feel it will be better to make a distinction by using words instead of arrows so that the user knows the distinction on first glance