### PR TITLE
Added some punctuation for consistency and correction

### DIFF
--- a/src/Pages/Learn/Lesson3.jsx
+++ b/src/Pages/Learn/Lesson3.jsx
@@ -153,7 +153,7 @@ function Lesson3({ setIsSideNavShowing, lesson3Data, setLesson3Data }) {
                 setStateToUpdate={setLesson3Data}
                 property="gridTemplateArea3"
               />
-              "
+              ";
             </CodeLine>
             <CodeLine>&#125;</CodeLine>
 

--- a/src/Pages/Learn/Lesson4.jsx
+++ b/src/Pages/Learn/Lesson4.jsx
@@ -113,6 +113,7 @@ function Lesson4({ setIsSideNavShowing, lesson4Data, setLesson4Data }) {
                 setStateToUpdate={setLesson4Data}
                 property="gridTemplateCols"
               />
+              ;
             </CodeLine>
             <CodeLine textIndent="1em">
               grid-template-rows:{" "}

--- a/src/Pages/Quiz/QuizQuestionComponents.jsx
+++ b/src/Pages/Quiz/QuizQuestionComponents.jsx
@@ -9,28 +9,34 @@ function QuizQuestionComponents({ id, answerData, setAnswerData }) {
         <CodeContainer margin="1rem 0">
           <CodeLine>grid-template-areas:</CodeLine>
           <CodeLine textIndent="1em">
+            "
             <StyledInput
               width="15rem"
               stateToUpdate={answerData}
               setStateToUpdate={setAnswerData}
               property="gridTemplateArea1"
             />
+            "
           </CodeLine>
           <CodeLine textIndent="1em">
+            "
             <StyledInput
               width="15rem"
               stateToUpdate={answerData}
               setStateToUpdate={setAnswerData}
               property="gridTemplateArea2"
             />
+            "
           </CodeLine>
           <CodeLine textIndent="1em">
+            "
             <StyledInput
               width="15rem"
               stateToUpdate={answerData}
               setStateToUpdate={setAnswerData}
               property="gridTemplateArea3"
             />
+            "
           </CodeLine>
           ;
         </CodeContainer>


### PR DESCRIPTION
Quotation marks for Quiz Question 2
- When going through question 2 of the quiz, there wasn't any quotation marks shown in the `grid-template-area` blanks, so I added my own. It was only after submission that I realised you didn't require the user to add them.

Semicolons in Lessons 3 and 4
- This is just for consistency, but I saw that there were missing semicolons in the CSS shown.